### PR TITLE
Update to fix CVE-2020-8244

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/dweinstein/last-bytes#readme",
   "dependencies": {
-    "bl": "^1.1.2",
+    "bl": "rvagg/bl#v1.2.3",
     "through2": "^2.0.1"
   }
 }


### PR DESCRIPTION
Fix for https://github.com/advisories/GHSA-pp7h-53gx-mx7r.  A package for v1.2.3 has not been published; hence using the github tag.